### PR TITLE
`pvdeg_tutorials/README.md`: install from conda-forge instead of obsolete pvlib channel

### DIFF
--- a/pvdeg_tutorials/README.md
+++ b/pvdeg_tutorials/README.md
@@ -33,7 +33,7 @@ steps:
    this tutorial. To install them using conda run:
 
    ```
-   conda create -n pvdeg jupyter -c pvlib --file requirements.txt
+   conda create -n pvdeg jupyter -c conda-forge --file requirements.txt
    conda activate pvdeg
    ```
 


### PR DESCRIPTION
This README file currently suggests using `-c pvlib` to install from the [pvlib anaconda channel](https://anaconda.org/pvlib/pvlib/files), which we aren't updating as of v0.9.5: See https://pvlib-python.readthedocs.io/en/v0.9.5/whatsnew.html

Better to use [conda-forge](https://anaconda.org/conda-forge/pvlib/files) now, for the pvlib installation at least.  However, I suggest evaluating whether using `conda-forge` might be undesirable for any other dependencies before merging this PR.