### PR TITLE
weather.get() bug fix PR

### DIFF
--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -46,6 +46,8 @@ def get(database, id=None, geospatial=False, **kwargs):
         Dictionary of metadata for the weather data
     """
 
+    META_MAP = {"elevation": "altitude", "Local Time Zone": "timezone"} # bug fix
+
     if type(id) is tuple:
         location = id
         gid = None


### PR DESCRIPTION
## Describe your changes

Restored the META_MAP dictionary in weather.get()

Fixes:
Value Error from undefined variable inside weather,get()

To reproduce: run the following code on development branch
```
weather_db = 'PSM3'
weather_id = (25.783388, -80.189029)
weather_arg = {'api_key': 'DEMO_KEY',
               'email': 'user@mail.com',
               'names': 'tmy',
               'attributes': [],
               'map_variables': True}

weather_df, meta = pvdeg.weather.get(weather_db, weather_id, **weather_arg)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code changes are covered by tests.
- [x] Example notebooks are rerun and differences in results scrutinized
