### PR TITLE
Geo bug fix

### DIFF
--- a/docs/source/whatsnew/releases/v0.4.0.rst
+++ b/docs/source/whatsnew/releases/v0.4.0.rst
@@ -13,7 +13,8 @@ Scenarios
 * Added geospatial bounding box support. Clip unwanted data with rectangular bounding boxes. See: ``geospatial.apply_bounding_box``
 * Added stochastic non-uniform density downselection function to preferentially select for mountains (higher point density with changes in elevation, lower density when flatter.) See:  ``geospatial.elevation_stochastic_downselection``
 * Updated non-uniform downselection with thresholding and non-linear normalization (support for logarithmic and exponential normalization) See: ``geospatial.identify_mountains_weights``
-* Added Scenario and GeospatialScenario methods for quick plotting and downselection. See: ``GeospatialScenario.plot_coords``, ``GeospatialScenario.plot_meta_classification``, ``GeospatialScenario.plot_USA``, ``Scenario.extract``, ``Scenario.plot``, ``GeospatialScenario.classify_mountain_weights``, ``GeospatialScenario.classify_mountain_radii``, ``GeospatialScenario.downselect_elevation_stochastic``
+* Added Scenario and GeospatialScenario methods for quick plotting and downselection. See: ``GeospatialScenario.plot_coords``, ``GeospatialScenario.plot_meta_classification``, ``GeospatialScenario.plot_USA``, ``Scenario.extract``, ``Scenario.plot``, ``GeospatialScenario.classify_mountain_weights``, ``GeospatialScenario.classify_mountain_radii``, ``GeospatialScenario.downselect_elevation_stochastic``.  
+* Added a convenience method ``GepspatialScenario.geospatial_data`` to quickly pull the geospatial weather and metadata from a scenario. Matches the API for ``pvdeg.weather.get``.  
 
 Geospatial Improvements  
 
@@ -40,6 +41,7 @@ Bug Fixes
 * Replaced deprecated numba `jit(nopython=True)` calls with `njit`
 * Fix incorrect keyword arguments in `pvdeg.standards.T98_estimate`
 * Fixed ``pvdeg.temperature.module`` and ``pvdeg.temperature.cell`` docstring return type. Correct return type ``pd.Series``
+* Fixed broken Geospatial Analysis, when using chunked (dask) xarrays for weather data
 
 Dependencies
 ------------

--- a/pvdeg/geospatial.py
+++ b/pvdeg/geospatial.py
@@ -269,9 +269,6 @@ def output_template(
     dims = set([d for dim in shapes.values() for d in dim])
     dims_size = dict(ds_gids.sizes) | add_dims
 
-    # if len(ds_gids.chunks) == 0:
-    #     raise ValueError(f"argument ds_gids must contain chunks")
-
     output_template = xr.Dataset(
         data_vars={
             var: (dim, da.empty([dims_size[d] for d in dim]), attrs.get(var))
@@ -279,7 +276,10 @@ def output_template(
         },
         coords={dim: ds_gids[dim] for dim in dims},
         attrs=global_attrs,
-    )  # .chunk({dim: ds_gids.chunks[dim] for dim in dims})
+    ) # moved chunks down from here
+    
+    if ds_gids.chunks: # chunk to match input
+        output_template = output_template.chunk({dim: ds_gids.chunks[dim] for dim in dims})
 
     return output_template
 

--- a/pvdeg/scenario.py
+++ b/pvdeg/scenario.py
@@ -1206,7 +1206,9 @@ class GeospatialScenario(Scenario):
 
             geo_meta = geo_meta[geo_meta["county"].isin(county)]
 
-        geo_meta, geo_gids = pvdeg.utilities.gid_downsampling(
+        # we don't downsample weather data until this runs 
+        # because on NSRDB we are storing weather OUT of MEMORY with dask
+        geo_meta, geo_gids = pvdeg.utilities.gid_downsampling( 
             geo_meta, downsample_factor
         )
 
@@ -1524,6 +1526,29 @@ class GeospatialScenario(Scenario):
         )
 
         return coords
+
+    def geospatial_data(self) -> tuple[xr.Dataset, pd.DataFrame]:
+        """
+        Extract the geospatial weather dataset and metadata dataframe from the scenario object
+        
+        Example Use:
+        >>> geo_weather, geo_meta = GeospatialScenario.geospatial_data()
+
+        This gets us the result we would use in the traditional pvdeg geospatial approach.
+
+        Parameters:
+        -----------
+        None
+
+        Returns:
+        --------
+        (weather_data, meta_data): (xr.Dataset, pd.DataFrame)        
+            A tuple of weather data as an `xarray.Dataset` and the corresponding meta data as a dataframe.
+        """
+        # downsample here, not done already happens at pipeline runtime
+        geo_weather_sub = self.weather_data.sel(gid=self.meta_data.index) 
+        return geo_weather_sub, self.meta_data
+        
 
     def addJob(
         self,

--- a/tests/test_geospatial.py
+++ b/tests/test_geospatial.py
@@ -17,7 +17,7 @@ HUMIDITY_TEMPLATE = xr.open_dataset(
 ).compute()
 
 
-def test_analysis_standoff():
+def test_analysis_standoff_unchunked():
     res_ds = pvdeg.geospatial.analysis(
         weather_ds=GEO_WEATHER,
         meta_df=GEO_META,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -131,6 +131,7 @@ def test_add_material():
         json.dump(data, f, indent=4)
 
 
+# this only works because we are not running on kestrel
 def test_nrel_kestrel_check_bad():
     with pytest.raises(ConnectionError):
         pvdeg.utilities.nrel_kestrel_check()


### PR DESCRIPTION
## Describe your changes

Geospatial analysis on chunked weather datasets was failing due to incorrectly shaped templates. We didn't catch this because there is no testing for it. #111 (still need to add this). 

`pvdeg.geospatial.output_template` would always produce an output with a single chunk along the gid axis. This was fine when the input was not chunked because it is treated as 1 block, similar to how we would treat the input if it had a single chunk. The problem comes when the input `xr.Dataset` was chunked with more than one chunk along the gid axis. See the screenshot below, there was one chunk along the time axis (irrelevant) and many chunks along the gid axis.
![image](https://github.com/user-attachments/assets/f82f665b-bceb-4377-b75b-ec0aee4617da)

This issue affected every `geospatial.analysis` call because the issue was the `geospatial.output_template` function incorrectly chunking the template, this caused `geospatial.autotemplate` to be broken, as well as the hard coded cases within the `geospatial.analysis` function. Both of the previous functions utilize the output_template function. *This highlights the need for chunked templating testing as well.*



## Issue ticket number and link


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code changes are covered by tests.
- [x] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] API.rst is up to date, along with other sphinx docs pages
- [x] Example notebooks are rerun and differences in results scrutinized
- [x] What's new changelog has been updated in the docs
