### PR TITLE
weather.get geospatial docstring example

### DIFF
--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -67,7 +67,7 @@ def get(database, id=None, geospatial=False, **kwargs):
         Dictionary of metadata for the weather data
 
 
-    Example
+    Examples
     --------
     Collecting a single site of PSM3 NSRDB data. *Api key and email must be replaced with your personal api key and email*. [Request a key!](https://developer.nrel.gov/signup/)
 
@@ -89,6 +89,33 @@ def get(database, id=None, geospatial=False, **kwargs):
     .. code-block:: python
 
         weather_df, meta_dict = pvdeg.weather.get(database="PVGIS", id=(49.95, 1.5))
+
+    Collecting geospatial data from NSRDB on Kestrel (NREL INTERNAL USERS ONLY)
+
+    satellite options:
+        ``"GOES", "METEOSAT", "Himawari", "SUNY", "CONUS", "Americas"``
+
+
+    .. code-block:: python
+
+        weather_db = "NSRDB"
+        weather_arg = {
+            "satellite": "Americas",
+            "names": "TMY",
+            "NREL_HPC": True,
+            "attributes": [
+                    "air_temperature",
+                    "wind_speed",
+                    "dhi",
+                    "ghi",
+                    "dni",
+                    "relative_humidity",
+                ],
+        }
+
+        geo_weather, geo_meta = pvdeg.weather.get(
+            weather_db, geospatial=True, **weather_arg
+        )
     """
 
     META_MAP = {"elevation": "altitude", "Local Time Zone": "tz"}


### PR DESCRIPTION
## Describe your changes

Added docstring example for `weather.get` with `geospatial=True` and information about available satellites.

## Issue ticket number and link

#153 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code