### PR TITLE
Add flake8 workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,18 @@
+# flake8 linter configurations
+# see https://flake8.pycqa.org/en/latest/user/options.html
+
+[flake8]
+# E203 is not PEP8 compliant https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#slices
+# Is excluded from flake8's own config https://flake8.pycqa.org/en/latest/user/configuration.html
+extend-ignore = E203
+max-line-length = 88
+max-doc-length = 88
+per-file-ignores =
+    # rdtools.x.y imported but unused
+    __init__.py:F401
+    # invalid escape sequence '\s'
+    versioneer.py:W605
+exclude =
+    docs
+    .eggs
+    build

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,0 +1,30 @@
+name: flake8
+
+on: [pull_request]
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install flake8
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+    - name: List changed files
+      run: |
+        git diff --compact-summary "origin/$GITHUB_BASE_REF"
+    - name: Run linter
+      run: |
+        flake8 . --config=.flake8 --count --statistics --show-source

--- a/docs/source/user_guide/contributing.rst
+++ b/docs/source/user_guide/contributing.rst
@@ -173,7 +173,7 @@ Code style
 
 pvdeg generally follows the `PEP 8 -- Style Guide for Python Code
 <https://www.python.org/dev/peps/pep-0008/>`_. Maximum line length for code
-is 79 characters.
+is 88 characters.
 
 Code must be compatible with Python 3.5 and above.
 


### PR DESCRIPTION
## Describe your changes

Add flake8 workflow. Config file inspired by rdtools, changes include max line length from 99 to 88 (Black's default).
Current workflow is triggered in PRs and lints the entire repository, not only diffs in the new PR. In future, to speed things up, we could change this to lint only diffs in the pr.

Note: flake8 test will not pass in this PR since the current codebase is not in compliance. Separate PR(s) will update the existing codebase.

## Issue ticket number and link

Fixes #164 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] Code changes are covered by tests.
- [ ] ~Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)~
- [ ] ~Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)~
- [ ] ~New functions added to __init__.py~
- [X] API.rst is up to date, along with other sphinx docs pages
- [ ] ~Example notebooks are rerun and differences in results scrutinized~
- [ ] What's new changelog has been updated in the docs