### PR TITLE
`spectral.poa_irradiance` is incorrectly called in `temperature.py`

### DIFF
--- a/pvdeg/temperature.py
+++ b/pvdeg/temperature.py
@@ -273,7 +273,7 @@ def cell(
     parameters = pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS[temp_model][conf]
 
     if poa is None:
-        poa = pvdeg.spectral.poa_irradiance(weather_df, meta)
+        poa = spectral.poa_irradiance(weather_df, meta)
 
     if temp_model == "sapm":
         temp_cell = pvlib.temperature.sapm_cell(


### PR DESCRIPTION
## Describe your changes

Just a quick fix. `pvdeg.spectral` is imported directly, so the `poa_irradiance` function only needs to be called as `spectral.poa_irradiance` rather than `pvdeg.spectral.poa_irradiance`. The original resulted in a syntax error.

Note:
linting test failures are unrelated to changes in this PR and are being resolved separately.
pytest failure noted [here](https://github.com/NREL/PVDegradationTools/pull/166#issuecomment-2992573840) is unrelated to changes in this PR and needs to be resolved separately

## Issue ticket number and link

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] Code changes are covered by tests.
- [ ] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)
- [ ] New functions added to __init__.py
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] What's new changelog has been updated in the docs
