### PR TITLE
Prevent tests skipping due to single failure

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
         python -m pip install --progress-bar off ${{ matrix.env }}
     - name: Test with pytest ${{ matrix.env }}
       run: |
-        python -m pytest --cov=./ --cov-report=xml
+        python -m pytest --maxfail=0 --cov=./ --cov-report=xml
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ include = ["pvdeg"]
 [tool.setuptools_scm]
 
 [tool.pytest.ini_options]
-maxfail = 0
 testpaths = "tests"
 addopts = [
     "-p no:warnings",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ include = ["pvdeg"]
 [tool.setuptools_scm]
 
 [tool.pytest.ini_options]
+maxfail = 0
 testpaths = "tests"
 addopts = [
     "-p no:warnings",


### PR DESCRIPTION
## Describe your changes

Configure pytest to continue running all tests when individual test cases fail.
Since we are not pushing many PRs, GitHub actions is not overloaded, so I don't think there's any harm in running the additional tests in order to compile all errors at once so they can be fixed collectively by the author.

Currently, if a single test function within a single test file fails, all other test functions in the entire matrix job of different python versions/environments are skipped.

This is just a suggestion, feel free to disagree. It just came to mind while working on #185.
@martin-springer thoughts?

## Issue ticket number and link

~Fixes # (issue)~

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [X] I have performed a self-review of my code

- [ ] What's new changelog has been updated in the docs
