### PR TITLE
Update flake8 workflow to linter only lines changed in PR

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -4,7 +4,6 @@ on: [pull_request]
 
 jobs:
   lint:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,10 +20,11 @@ jobs:
     - name: Install flake8
       run: |
         python -m pip install --upgrade pip
-        pip install flake8
-    - name: List changed files
+        pip install flake8==5.0.4  # use this version for --diff option
+    - name: Fetch PR target branch
       run: |
-        git diff --compact-summary "origin/$GITHUB_BASE_REF"
-    - name: Run linter
+        git fetch origin $GITHUB_BASE_REF
+    - name: Run flake8 on changed files only
       run: |
-        flake8 . --config=.flake8 --count --statistics --show-source
+        git diff origin/$GITHUB_BASE_REF HEAD -- "*.py" | flake8 --config=.flake8 --diff
+  


### PR DESCRIPTION
## Describe your changes

Now that #175 / #166 have been merged, I am updating the flake8 workflow so that only lines changed in a PR are checked by the linter. 
Originally, the entire repo was being checked, so that we could review and fix linting issues in a single PR. Most of these have now been fixed, so we can move to checking only changed lines in future PRs.

## Issue ticket number and link

Relates to #164 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code changes are covered by tests.
- [x] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] What's new changelog has been updated in the docs
