### PR TITLE
Suggestion: add concurrency control to pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,9 @@ on:
     - development
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/docs/source/whatsnew/releases/v0.5.1.rst
+++ b/docs/source/whatsnew/releases/v0.5.1.rst
@@ -7,6 +7,8 @@ Enhancements
 - Changed ``GeospatialScenario.coords_tonumpy()`` to a ``@property``, now use ``GeospatialScenario.coords``
 - Refactor ``META_MAP`` in :py:mod:`pvdeg.weather` to module-level constant
   (:pull:`182`)
+- Updated pytest workflow to cancel in-progress runs for the same branch in favour of
+  running on the latest commit. (:pull:`191`)
 
 Deprecations
 -------------


### PR DESCRIPTION
## Describe your changes

I noticed while working on #184 that if one commit immediately follows another, our tests won't run on the latest commit until they have finished running on the previous commit. I think it would be more efficient to run tests only on the latest commit, and interrupt ongoing tests if a new commit is pushed to the same branch.

This is just a suggestion. feel free to disagree with the premise of this PR. As it's only a quick fix I figured I'd just open a PR first.

## Issue ticket number and link

~Fixes # (issue)~

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] What's new changelog has been updated in the docs
