### PR TITLE
Replace `UserWarning` with print statement in `scenario.py` when adding objects is successful 

### DIFF
--- a/pvdeg/scenario.py
+++ b/pvdeg/scenario.py
@@ -234,7 +234,7 @@ class Scenario:
 
         if see_added and weather_db == "PSM3":
             message = f"Gids Added - {self.gids}"
-            warnings.warn(message, UserWarning)
+            print(message)
 
     def addModule(
         self,
@@ -417,7 +417,7 @@ class Scenario:
 
         if see_added:
             message = f"{func.__name__} added to pipeline as \n {job_dict}"
-            warnings.warn(message, UserWarning)
+            print(message)
 
     def run(self):
         """

--- a/pvdeg/scenario.py
+++ b/pvdeg/scenario.py
@@ -314,7 +314,8 @@ class Scenario:
         )
 
         if see_added:
-            print(f'Module "{module_name}" added.')
+            message = f"Module {module_name} added."
+            print(message)
 
     # add testing
     def add_material(


### PR DESCRIPTION
## Describe your changes

If an object  (job, module...) is _successfully_ added, a `UserWarning` is emitted. This seems inappropriate, warnings should be reserved for alerting the user of a problem. I have replaced the `UserWarning` with a simple print statement in such cases in the `scenario.py` file.

## Issue ticket number and link

~Fixes # (issue)~

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code changes are covered by tests.
- [ ] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)
- [ ] New functions added to __init__.py
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] What's new changelog has been updated in the docs
