### PR TITLE
Update flake8 exclusions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,5 +15,7 @@ per-file-ignores =
 exclude =
     docs
     .eggs
+    .git
+    .venv
     build
-    tutorials_and_tools/tutorials_and_tools/*.py
+    tutorials_and_tools


### PR DESCRIPTION
## Describe your changes

`flake8 .` not running properly locally, and throwing unimportant errors resolution:

Add the following exclusions `.venv`, `.git`
Modify the `tutorials_and_tools` exclusion

Justification
Add `.venv`:  virtual environment contains installed packages and dependencies — not codebase python files. No need to lint this
Add `.git` contains internal Git metadata — not codebase python. No need to lint this.

`tutorials_and_tools/tutorials_and_tools/*.py` --> `tutorials_and_tools`: local flake8 check doesn't seem to recognise the `*.py` filter, but excluding the entire folder works. This also means the `.ipynb` files. Is this okay?

## Issue ticket number and link

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code changes are covered by tests.
- [ ] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)
- [ ] New functions added to __init__.py
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] What's new changelog has been updated in the docs
