### PR TITLE
[WIP] Format kinematic parameters database to include placeholders for units and stdev

### DIFF
--- a/pvdeg/data/kinetic_parameters.json
+++ b/pvdeg/data/kinetic_parameters.json
@@ -1,279 +1,1119 @@
 {
     "repins": {
         "mechanism": "LETID",
-        "v_ab": 46700000.0,
-        "v_ba": 4.7e-25,
-        "v_bc": 19900000.0,
-        "v_cb": 0.0,
-        "ea_ab": 0.827,
-        "ea_ba": -1.15,
-        "ea_bc": 0.871,
-        "ea_cb": 0.0,
-        "suns_ab": 1.0,
-        "suns_bc": 1.0,
-        "temperature_ab": 410,
-        "temperature_bc": 410,
-        "tau_ab": 75,
-        "tau_bc": 75,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 46700000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 4.7e-25,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 19900000.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.827,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": -1.15,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.871,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "cell",
         "structure_bc": "cell",
-        "thickness_ab": 200,
-        "thickness_bc": 200,
-        "srv_ab": 90,
-        "srv_bc": 90,
+        "thickness_ab": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
         "doi": "doi:10.1557/s43577-022-00438-8",
         "comments": ""
     },
     "repins_best_case": {
         "mechanism": "LETID",
-        "v_ab": 46700000.0,
-        "v_ba": 4.7e-25,
-        "v_bc": 19900000.0,
-        "v_cb": 0.0,
-        "ea_ab": 0.827,
-        "ea_ba": -1.15,
-        "ea_bc": 0.771,
-        "ea_cb": 0.0,
-        "suns_ab": 1.0,
-        "suns_bc": 1.0,
-        "temperature_ab": 410,
-        "temperature_bc": 410,
-        "tau_ab": 75,
-        "tau_bc": 75,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 46700000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 4.7e-25,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 19900000.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.827,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": -1.15,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.771,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "cell",
         "structure_bc": "cell",
-        "thickness_ab": 200,
-        "thickness_bc": 200,
-        "srv_ab": 90,
-        "srv_bc": 90,
+        "thickness_ab": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
         "doi": "doi:10.1557/s43577-022-00438-8",
         "comments": ""
     },
     "kwapil": {
         "mechanism": "LETID",
-        "v_ab": 33000000.0,
-        "v_ba": 4.7e-25,
-        "v_bc": 13100000.0,
-        "v_cb": 0.0,
-        "ea_ab": 0.827,
-        "ea_ba": -1.15,
-        "ea_bc": 0.871,
-        "ea_cb": 0.0,
-        "suns_ab": 1.0,
-        "suns_bc": 1.0,
-        "temperature_ab": 410,
-        "temperature_bc": 410,
-        "tau_ab": 75,
-        "tau_bc": 75,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 33000000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 4.7e-25,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 13100000.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.827,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": -1.15,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.871,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "cell",
         "structure_bc": "cell",
-        "thickness_ab": 200,
-        "thickness_bc": 200,
-        "srv_ab": 90,
-        "srv_bc": 90,
+        "thickness_ab": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
         "doi": "doi:10.1016/j.solmat.2017.05.066, doi:10.1109/JPHOTOV.2020.3025240",
         "comments": ""
     },
     "bredemeier": {
         "mechanism": "LETID",
-        "v_ab": 937000000.0,
-        "v_ba": 0.0,
-        "v_bc": 21500000.0,
-        "v_cb": 0.0,
-        "ea_ab": 0.94,
-        "ea_ba": 0.0,
-        "ea_bc": 0.941,
-        "ea_cb": 0.0,
-        "suns_ab": 0.5,
-        "suns_bc": 1.0,
-        "temperature_ab": 373,
-        "temperature_bc": 135,
-        "tau_ab": 185,
-        "tau_bc": 75,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 937000000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 21500000.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.94,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.941,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 0.5,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 373,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 135,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 185,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "wafer",
         "structure_bc": "cell",
-        "thickness_ab": 158,
-        "thickness_bc": 200,
-        "srv_ab": 0,
-        "srv_bc": 90,
+        "thickness_ab": {
+            "units": "",
+            "value": 158,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
         "doi": "doi:10.1016/j.solmat.2017.08.007",
         "comments": ""
     },
     "wyller_wafer": {
         "mechanism": "LETID",
-        "v_ab": 1900000000000.0,
-        "v_ba": 0.0,
-        "v_bc": 0.284,
-        "v_cb": 0.0,
-        "ea_ab": 1.38,
-        "ea_ba": 0.0,
-        "ea_bc": 0.56,
-        "ea_cb": 0.0,
-        "suns_ab": 1.0,
-        "suns_bc": 1.0,
-        "temperature_ab": 423,
-        "temperature_bc": 423,
-        "tau_ab": 200,
-        "tau_bc": 200,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 1900000000000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 0.284,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 1.38,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.56,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 423,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 423,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "wafer",
         "structure_bc": "wafer",
-        "thickness_ab": 180,
-        "thickness_bc": 180,
-        "srv_ab": 0,
-        "srv_bc": 0,
+        "thickness_ab": {
+            "units": "",
+            "value": 180,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 180,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
         "doi": "doi:10.1109/JPHOTOV.2021.3078367",
         "comments": ""
     },
     "wyller_cell": {
         "mechanism": "LETID",
-        "v_ab": 483000.0,
-        "v_ba": 0.0,
-        "v_bc": 0.0,
-        "v_cb": 0.0,
-        "ea_ab": 0.664,
-        "ea_ba": 0.0,
-        "ea_bc": 0.941,
-        "ea_cb": 0.0,
-        "suns_ab": 1.0,
-        "suns_bc": 1.0,
-        "temperature_ab": 410,
-        "temperature_bc": 410,
-        "tau_ab": 75,
-        "tau_bc": 75,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 483000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.664,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.941,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 410,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 75,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "cell",
         "structure_bc": "cell",
-        "thickness_ab": 200,
-        "thickness_bc": 200,
-        "srv_ab": 90,
-        "srv_bc": 90,
+        "thickness_ab": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 90,
+            "stdev": ""
+        },
         "doi": "doi:10.1109/JPHOTOV.2021.3078367",
         "comments": ""
     },
     "graf": {
         "mechanism": "LETID",
-        "v_ab": 483000.0,
-        "v_ba": 0.0,
-        "v_bc": 0.0,
-        "v_cb": 0.0,
-        "ea_ab": 0.78,
-        "ea_ba": 0.0,
-        "ea_bc": 0.62,
-        "ea_cb": 0.0,
-        "suns_ab": 1.0,
-        "suns_bc": 1.0,
-        "temperature_ab": 423,
-        "temperature_bc": 423,
-        "tau_ab": 180,
-        "tau_bc": 180,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 483000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.78,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.62,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 423,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 423,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 180,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 180,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "wafer",
         "structure_bc": "wafer",
-        "thickness_ab": 152,
-        "thickness_bc": 152,
-        "srv_ab": 0,
-        "srv_bc": 0,
+        "thickness_ab": {
+            "units": "",
+            "value": 152,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 152,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
         "doi": "doi:10.1063/1.5123890",
         "comments": ""
     },
     "dark letid": {
         "mechanism": "Dark LETID",
-        "v_ab": 84400000.0,
-        "v_ba": 0.0,
-        "v_bc": 17900000.0,
-        "v_cb": 0.0,
-        "ea_ab": 1.08,
-        "ea_ba": 0.0,
-        "ea_bc": 1.11,
-        "ea_cb": 0.0,
-        "suns_ab": 1.0,
-        "suns_bc": 1.0,
-        "temperature_ab": 402,
-        "temperature_bc": 402,
-        "tau_ab": 154,
-        "tau_bc": 154,
-        "x_ab": 1,
-        "x_ba": 1.7,
-        "x_bc": 1.2,
+        "v_ab": {
+            "units": "",
+            "value": 84400000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 17900000.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 1.08,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 1.11,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.0,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 1.0,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 402,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 402,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 154,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 154,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1.7,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 1.2,
+            "stdev": ""
+        },
         "structure_ab": "wafer",
         "structure_bc": "wafer",
-        "thickness_ab": 192,
-        "thickness_bc": 192,
-        "srv_ab": 0,
-        "srv_bc": 0,
+        "thickness_ab": {
+            "units": "",
+            "value": 192,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 192,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
         "comments": ""
     },
     "bo-lid": {
         "mechanism": "BO-LID",
-        "v_ab": 4000.0,
-        "v_ba": 10000000000000.0,
-        "v_bc": 12500000000.0,
-        "v_cb": 532000.0,
-        "ea_ab": 0.475,
-        "ea_ba": 1.32,
-        "ea_bc": 0.98,
-        "ea_cb": 0.87,
-        "suns_ab": 0.1,
-        "suns_bc": 2.7,
-        "temperature_ab": 400,
-        "temperature_bc": 434,
-        "tau_ab": 140,
-        "tau_bc": 165,
-        "x_ab": 0,
-        "x_ba": 1,
-        "x_bc": 0,
+        "v_ab": {
+            "units": "",
+            "value": 4000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 10000000000000.0,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 12500000000.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 532000.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.475,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": 1.32,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.98,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.87,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 0.1,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 2.7,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 400,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 434,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 140,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 165,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
         "structure_ab": "wafer",
         "structure_bc": "wafer",
-        "thickness_ab": 200,
-        "thickness_bc": 200,
-        "srv_ab": 0,
-        "srv_bc": 0,
+        "thickness_ab": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
         "comments": ""
     },
     "Lit BO-LID + fit to Qcells destab": {
         "mechanism": "BO-LID",
-        "v_ab": 4000.0,
-        "v_ba": 10000000000000.0,
-        "v_bc": 12500000000.0,
-        "v_cb": 500000.0,
-        "ea_ab": 0.475,
-        "ea_ba": 1.32,
-        "ea_bc": 0.98,
-        "ea_cb": 0.87,
-        "suns_ab": 0.1,
-        "suns_bc": 2.7,
-        "temperature_ab": 400,
-        "temperature_bc": 434,
-        "tau_ab": 140,
-        "tau_bc": 165,
-        "x_ab": 0,
-        "x_ba": 1,
-        "x_bc": 0,
+        "v_ab": {
+            "units": "",
+            "value": 4000.0,
+            "stdev": ""
+        },
+        "v_ba": {
+            "units": "",
+            "value": 10000000000000.0,
+            "stdev": ""
+        },
+        "v_bc": {
+            "units": "",
+            "value": 12500000000.0,
+            "stdev": ""
+        },
+        "v_cb": {
+            "units": "",
+            "value": 500000.0,
+            "stdev": ""
+        },
+        "ea_ab": {
+            "units": "",
+            "value": 0.475,
+            "stdev": ""
+        },
+        "ea_ba": {
+            "units": "",
+            "value": 1.32,
+            "stdev": ""
+        },
+        "ea_bc": {
+            "units": "",
+            "value": 0.98,
+            "stdev": ""
+        },
+        "ea_cb": {
+            "units": "",
+            "value": 0.87,
+            "stdev": ""
+        },
+        "suns_ab": {
+            "units": "",
+            "value": 0.1,
+            "stdev": ""
+        },
+        "suns_bc": {
+            "units": "",
+            "value": 2.7,
+            "stdev": ""
+        },
+        "temperature_ab": {
+            "units": "",
+            "value": 400,
+            "stdev": ""
+        },
+        "temperature_bc": {
+            "units": "",
+            "value": 434,
+            "stdev": ""
+        },
+        "tau_ab": {
+            "units": "",
+            "value": 140,
+            "stdev": ""
+        },
+        "tau_bc": {
+            "units": "",
+            "value": 165,
+            "stdev": ""
+        },
+        "x_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "x_ba": {
+            "units": "",
+            "value": 1,
+            "stdev": ""
+        },
+        "x_bc": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
         "structure_ab": "wafer",
         "structure_bc": "wafer",
-        "thickness_ab": 200,
-        "thickness_bc": 200,
-        "srv_ab": 0,
-        "srv_bc": 0,
+        "thickness_ab": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "thickness_bc": {
+            "units": "",
+            "value": 200,
+            "stdev": ""
+        },
+        "srv_ab": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
+        "srv_bc": {
+            "units": "",
+            "value": 0,
+            "stdev": ""
+        },
         "comments": ""
     }
 }


### PR DESCRIPTION
## Describe your changes

Reformatted the kinematic parameters database to include spaces for each float parameter to add units and standard deviation. This is similar to the formatting of the degradation database.

## Issue ticket number and link

Fixes #211 
Related #202 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code changes are covered by tests.
- [ ] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)
- [ ] New functions added to __init__.py
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] What's new changelog has been updated in the docs
