### PR TITLE
Add PVDeg logo to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-<img src="docs/source/_static/logo-vectors/PVdeg-Logo-Horiz-Color.svg" width="600">  
+<img src="https://raw.githubusercontent.com/NREL/PVDegradationTools/refs/heads/main/docs/source/_static/logo-vectors/PVdeg-Logo-Horiz-Color.svg" width="600">  
+
 
 <table>
 <tr>


### PR DESCRIPTION
## Describe your changes

Change README image source from a repo filepath to an external GitHub raw image link.

According to the stackoverflow discussion linked in #76 this fix works. The image is displaying correctly locally and on GitHub.

@martin-springer if you have access to the test pypi this could be checked more thoroughly. Otherwise we could just hope it works since it won't interrupt GitHub and in the worst case nothing on PyPI changes.

## Issue ticket number and link

Fixes #76 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] Code changes are covered by tests.
- [ ] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)
- [ ] New functions added to __init__.py
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] What's new changelog has been updated in the docs
