### PR TITLE
Change default value of `find_meta` to `False`

### DIFF
--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -259,7 +259,7 @@ def get(
         return weather_ds, meta_df
 
 
-def read(file_in, file_type, map_variables=True, find_meta=True, **kwargs):
+def read(file_in, file_type, map_variables=True, find_meta=False, **kwargs):
     """
     Read a locally stored weather file of any PVLIB compatible type
 


### PR DESCRIPTION
The previous default behavior `find_meta=True` triggers a network call, which leads to pytest issue when there is a connection error even when trying to read local files, e.g. in `test_design.py` (https://github.com/NREL/PVDegradationTools/pull/215#issuecomment-3246103392)