### PR TITLE
Add function to calculate relative humidity

### DIFF
--- a/docs/source/whatsnew/releases/v0.6.0.rst
+++ b/docs/source/whatsnew/releases/v0.6.0.rst
@@ -64,6 +64,8 @@ Enhancements
 - Add `"name"`, `"units"`, and `"value"` fields to the materials JSON databases
   `AApermeation.json`, `H2Opermeation.json`, and `O2permeation.json`.
   (:issue:`211`, :pull:`224`)
+- Add relative humidity calculation to :py:mod:`pvdeg.weather`.
+  (:issue:`227`, :pull:`228`)
 
 Deprecations
 -------------

--- a/docs/source/whatsnew/releases/v0.6.0.rst
+++ b/docs/source/whatsnew/releases/v0.6.0.rst
@@ -64,8 +64,8 @@ Enhancements
 - Add `"name"`, `"units"`, and `"value"` fields to the materials JSON databases
   `AApermeation.json`, `H2Opermeation.json`, and `O2permeation.json`.
   (:issue:`211`, :pull:`224`)
-- Add relative humidity calculation to :py:mod:`pvdeg.weather`.
-  (:issue:`227`, :pull:`228`)
+- Add new (public) function :py:mod:`pvdeg.humidity` to calculate relative humidity from
+  air temperature and dew point temperature. (:issue:`227`, :pull:`228`)
 
 Deprecations
 -------------

--- a/pvdeg/humidity.py
+++ b/pvdeg/humidity.py
@@ -25,22 +25,22 @@ def relative(temperature_air, dew_point):
 
     Parameters
     ----------
-    temperature_air : pd.Series
-        Datetime-indexed dataframe or series of ambient air temperature. [°C]
+    temperature_air : pd.Series or float
+        Series or float of ambient air temperature. [°C]
 
-    dew_point : pd.Series
-        Datetime-indexed series of dew point temperature. [°C]
+    dew_point : pd.Series or float
+        Series or float of dew point temperature. [°C]
 
     Notes
     -----
-    Passing NaN values in either ``temperature_air`` or ``dew_point`` at any datetime
+    Passing NaN values in either ``temperature_air`` or ``dew_point`` at any index
     position will return NaN values in the output at those same position(s) in
     ``relative_humidity``.
 
     Returns:
     --------
     relative_humidity : pd.Series
-        Datetime-indexed series containing ambient relative humidity. [%]
+        Series or float of ambient relative humidity. [%]
     """
     if temperature_air.isna().any() or dew_point.isna().any():
         warnings.warn("Input contains NaN values. Output will contain NaNs at those"

--- a/pvdeg/humidity.py
+++ b/pvdeg/humidity.py
@@ -37,9 +37,9 @@ def relative(temperature_air, dew_point):
     position will return NaN values in the output at those same position(s) in
     ``relative_humidity``.
 
-    Returns:
-    --------
-    relative_humidity : pd.Series
+    Returns
+    -------
+    relative_humidity : pd.Series or float
         Series or float of ambient relative humidity. [%]
     """
     if temperature_air.isna().any() or dew_point.isna().any():

--- a/pvdeg/humidity.py
+++ b/pvdeg/humidity.py
@@ -3,11 +3,53 @@
 import numpy as np
 import pandas as pd
 from numba import jit
+import warnings
 
 from pvdeg import temperature, spectral, decorators, utilities
 
 # Constants
 R_GAS = 0.00831446261815324  # Gas constant in kJ/(mol·K)
+
+
+def relative(temperature_air, dew_point):
+    """Calculate ambient relative humidity from dry bulb air temperature and dew point.
+
+    References
+    ----------
+    Alduchov, O. A., and R. E. Eskridge, 1996: Improved Magnus' form approximation of
+    saturation vapor pressure. J. Appl. Meteor., 35, 601–609.
+    August, E. F., 1828: Ueber die Berechnung der Expansivkraft des Wasserdunstes. Ann.
+    Phys. Chem., 13, 122–137.
+    Magnus, G., 1844: Versuche über die Spannkräfte des Wasserdampfs. Ann. Phys. Chem.,
+    61, 225–247.
+
+    Parameters
+    ----------
+    temperature_air : pd.Series
+        Datetime-indexed dataframe or series of ambient air temperature. [°C]
+
+    dew_point : pd.Series
+        Datetime-indexed series of dew point temperature. [°C]
+
+    Notes
+    -----
+    Passing NaN values in either ``temperature_air`` or ``dew_point`` at any datetime
+    position will return NaN values in the output at those same position(s) in
+    ``relative_humidity``.
+
+    Returns:
+    --------
+    relative_humidity : pd.Series
+        Datetime-indexed series containing ambient relative humidity. [%]
+    """
+    if temperature_air.isna().any() or dew_point.isna().any():
+        warnings.warn("Input contains NaN values. Output will contain NaNs at those"
+        "positions.")
+
+    num = np.exp(17.625 * dew_point / (243.04 + dew_point))
+    den = np.exp(17.625 * temperature_air / (243.04 + temperature_air))
+
+    return 100 * num / den
 
 
 # TODO: When is dew_yield used?

--- a/pvdeg/humidity.py
+++ b/pvdeg/humidity.py
@@ -42,9 +42,15 @@ def relative(temperature_air, dew_point):
     relative_humidity : pd.Series or float
         Series or float of ambient relative humidity. [%]
     """
-    if temperature_air.isna().any() or dew_point.isna().any():
-        warnings.warn("Input contains NaN values. Output will contain NaNs at those"
-        "positions.")
+    if (
+        (isinstance(temperature_air, pd.Series) and temperature_air.isna().any())
+        or (isinstance(dew_point, pd.Series) and dew_point.isna().any())
+        or (isinstance(temperature_air, float) and pd.isna(temperature_air))
+        or (isinstance(dew_point, float) and pd.isna(dew_point))
+    ):
+        warnings.warn(
+            "Input contains NaN values. Output will contain NaNs at those positions."
+        )
 
     num = np.exp(17.625 * dew_point / (243.04 + dew_point))
     den = np.exp(17.625 * temperature_air / (243.04 + temperature_air))

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -238,7 +238,8 @@ def get(
             dew_point = weather_df.get("dew_point")
             if dew_point or temp_air is None:
                 raise ValueError('Cannot calculate "relative_humidity": one of'
-                '"dew_point" or "temp_air" column not found in DataFrame.')
+                                 '"dew_point" or "temp_air" column not found in' \
+                                 'DataFrame.')
             numerator = np.exp(17.625 * dew_point / (243.04 + dew_point))
             denominator = np.exp(17.625 * temp_air / (243.04 + temp_air))
             weather_df["relative_humidity"] = 100 * numerator / denominator

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -234,7 +234,11 @@ def get(
                 'Column "relative_humidity" not found in DataFrame. Calculating...',
                 end="",
             )
-            weather_df = humidity._ambient(weather_df)
+            temp_air = weather_df["temp_air"]
+            dew_point = weather_df.get("dew_point")
+            numerator = np.exp(17.625 * dew_point / (243.04 + dew_point))
+            denominator = np.exp(17.625 * temp_air / (243.04 + temp_air))
+            weather_df["relative_humidity"] = 100 * numerator / denominator
             print(
                 "\r",
                 "                                                                    ",

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -240,9 +240,7 @@ def get(
                 raise ValueError('Cannot calculate "relative_humidity": one of'
                                  '"dew_point" or "temp_air" column not found in'
                                  'DataFrame.')
-            numerator = np.exp(17.625 * dew_point / (243.04 + dew_point))
-            denominator = np.exp(17.625 * temp_air / (243.04 + temp_air))
-            weather_df["relative_humidity"] = 100 * numerator / denominator
+            weather_df["relative_humidity"] = humidity.relative(temp_air, dew_point)
             print(
                 "\r",
                 "                                                                    ",

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -236,7 +236,7 @@ def get(
             )
             temp_air = weather_df["temp_air"]
             dew_point = weather_df.get("dew_point")
-            if dew_point or temp_air is None:
+            if dew_point is None or temp_air is None:
                 raise ValueError('Cannot calculate "relative_humidity": one of'
                                  '"dew_point" or "temp_air" column not found in'
                                  'DataFrame.')

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -238,7 +238,7 @@ def get(
             dew_point = weather_df.get("dew_point")
             if dew_point or temp_air is None:
                 raise ValueError('Cannot calculate "relative_humidity": one of'
-                                 '"dew_point" or "temp_air" column not found in' \
+                                 '"dew_point" or "temp_air" column not found in'
                                  'DataFrame.')
             numerator = np.exp(17.625 * dew_point / (243.04 + dew_point))
             denominator = np.exp(17.625 * temp_air / (243.04 + temp_air))

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -236,6 +236,9 @@ def get(
             )
             temp_air = weather_df["temp_air"]
             dew_point = weather_df.get("dew_point")
+            if dew_point or temp_air is None:
+                raise ValueError('Cannot calculate "relative_humidity": "dew_point" ' \
+                'column not found in DataFrame.')
             numerator = np.exp(17.625 * dew_point / (243.04 + dew_point))
             denominator = np.exp(17.625 * temp_air / (243.04 + temp_air))
             weather_df["relative_humidity"] = 100 * numerator / denominator

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -237,8 +237,8 @@ def get(
             temp_air = weather_df["temp_air"]
             dew_point = weather_df.get("dew_point")
             if dew_point or temp_air is None:
-                raise ValueError('Cannot calculate "relative_humidity": "dew_point" ' \
-                'column not found in DataFrame.')
+                raise ValueError('Cannot calculate "relative_humidity": one of'
+                '"dew_point" or "temp_air" column not found in DataFrame.')
             numerator = np.exp(17.625 * dew_point / (243.04 + dew_point))
             denominator = np.exp(17.625 * temp_air / (243.04 + temp_air))
             weather_df["relative_humidity"] = 100 * numerator / denominator

--- a/tests/test_humidity.py
+++ b/tests/test_humidity.py
@@ -39,12 +39,13 @@ def test_relative_series():
     expected = pd.Series([53.83, 28.94, 15.51])
     np.testing.assert_allclose(result, expected, atol=0.01)
 
+
 def test_relative_nan_combinations():
     test_cases = [
-        (pd.Series([25.0, np.nan]), pd.Series([15.0, 10.0])),
-        (pd.Series([25.0, 30.0]), pd.Series([15.0, np.nan])),
-        (np.nan, 10.0),
-        (25.0, np.nan),
+        (pd.Series([25.0, np.nan]), pd.Series([15.0, 10.0])),  # nan in temp series
+        (pd.Series([25.0, 30.0]), pd.Series([15.0, np.nan])),  # nan in dew series
+        (np.nan, 10.0),  # nan in temp float
+        (25.0, np.nan),  # nan in dew float
     ]
 
     for temp, dew in test_cases:

--- a/tests/test_humidity.py
+++ b/tests/test_humidity.py
@@ -8,7 +8,8 @@ import os
 import json
 import pandas as pd
 import pvdeg
-from pytest import approx
+import numpy as np
+import pytest
 from pvdeg import TEST_DATA_DIR
 
 # Load weather data
@@ -24,6 +25,31 @@ rh_expected = pd.read_csv(
 )
 rh_cols = [col for col in rh_expected.columns if "RH" in col]
 rh_expected = rh_expected[rh_cols]
+
+
+def test_relative_float():
+    result = pvdeg.humidity.relative(40.0, 30.0)
+    assert result == pytest.approx(57.45, abs=0.01)
+
+
+def test_relative_series():
+    temp = pd.Series([25.0, 30.0, 35.0])
+    dew = pd.Series([15.0, 10.0, 5.0])
+    result = pvdeg.humidity.relative(temp, dew)
+    expected = pd.Series([53.83, 28.94, 15.51])
+    np.testing.assert_allclose(result, expected, atol=0.01)
+
+def test_relative_nan_combinations():
+    test_cases = [
+        (pd.Series([25.0, np.nan]), pd.Series([15.0, 10.0])),
+        (pd.Series([25.0, 30.0]), pd.Series([15.0, np.nan])),
+        (np.nan, 10.0),
+        (25.0, np.nan),
+    ]
+
+    for temp, dew in test_cases:
+        with pytest.warns(UserWarning, match="Input contains NaN values"):
+            pvdeg.humidity.relative(temp, dew)
 
 
 def test_module():
@@ -52,7 +78,7 @@ def test_water_saturation_pressure():
     """
     water_saturation_pressure_avg = pvdeg.humidity.water_saturation_pressure(
         temp=WEATHER["temp_air"])[1]
-    assert water_saturation_pressure_avg == approx(0.47607, abs=5e-5)
+    assert water_saturation_pressure_avg == pytest.approx(0.47607, abs=5e-5)
 
 
 """


### PR DESCRIPTION
## Describe your changes

Address the first task highlighted in the linked issue
*EDIT*
Changing the scope of this PR. Instead of refactoring the calculation in the private `_ambient()` function from the humidity module to the weather module, `_ambient()` will be made public and then called in the weather module.

The original `_ambient` calculates relative humidity and then adds the calculated relative humidity as a column to `weather_df`. This behaviour will be separated so users can just use this function to calculate relative humidity themselves. Use of this function in the weather module (`weather.py`) has been updated accordingly.

The logic of `_ambient` has been significantly changed. For example, instead of taking a single dataframe with the required variables (temperature and dew point), the function can take individual arguments of temperature and dew point as either a series or float. There is no requirement for the input to be datetime-indexed.

Function name changed to `relative()`, returned variable name changed to `relative_humidity` (https://github.com/NREL/PVDegradationTools/issues/213#issuecomment-3253414003)

## Issue ticket number and link

Partially fixes #227

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [x] Code changes are covered by tests.
- [x]  New functions added to __init__.py
- [x] API.rst is up to date, along with other sphinx docs pages
- [x] What's new changelog has been updated in the docs
