### PR TITLE
Remove notebook check box from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,5 +23,4 @@ Please delete options that are not relevant.
 - [ ] Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)
 - [ ] New functions added to __init__.py
 - [ ] API.rst is up to date, along with other sphinx docs pages
-- [ ] Example notebooks are rerun and differences in results scrutinized
 - [ ] What's new changelog has been updated in the docs


### PR DESCRIPTION
Since we now have nbval checks, we can remove the task from the PR template that requires users to run all notebooks manually and check for discrepancies 🎉