### PR TITLE
Kestrel nsrdb fnames

### DIFF
--- a/docs/source/whatsnew/releases/v0.6.0.rst
+++ b/docs/source/whatsnew/releases/v0.6.0.rst
@@ -108,7 +108,9 @@ Bug Fixes
   - Improve code consistency
   (:issue:`177`, :pull:`178`)
 - Clean up and fix bugs in notebooks. (:issue:`179`, :pull:`184`)
-
+- Resolves non-deterministic source ambiguity when picking NSRDB TMY files from Kestrel when using ``weather.get(..., TMY=True, geospatial=True)``.
+  - PVDeg will always use the most recent version.
+  - Added new ``kestrel_nsrdb_fnames`` attribute to returned weather dataset for traceability.
 
 Dependencies
 ------------

--- a/pvdeg/utilities.py
+++ b/pvdeg/utilities.py
@@ -1388,7 +1388,7 @@ def display_json(
         html += (
             f"<div>"
             f'<strong style="color: white;">{key}:</strong> '  # noqa
-            f"<span onclick=\"this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'\" style=\"cursor: pointer; color: white;\">&#9660;</span>"  # noqa: E702,E231, E501
+            f"<span onclick=\"this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'\" style=\"cursor: pointer; color: white;\">&#9660;</span>"  # noqa: E702,E231,E501,W505
             f'<div style="display: none;">{json_to_html(value)}</div>'  # noqa
             f"</div>"
         )

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -655,13 +655,14 @@ def get_NSRDB_fnames(satellite, names, NREL_HPC=False, **_):
         nsrdb_fp = os.path.join(
             hpc_fp, sat_map[satellite], "*_{}*.h5".format(names.lower())
         )
-        nsrdb_fnames = sorted(glob.glob(nsrdb_fp))
+        nsrdb_fnames = glob.glob(nsrdb_fp)
 
     if len(nsrdb_fnames) == 0:
         raise FileNotFoundError(
             "Couldn't find NSRDB input files! \nSearched for: '{}'".format(nsrdb_fp)
         )
 
+    nsrdb_fnames = sorted(nsrdb_fnames)
     return nsrdb_fnames, hsds
 
 
@@ -768,10 +769,10 @@ def get_NSRDB(
 
         if isinstance(names, str) and names.lower() in ["tmy", "tmy3"]:
             # maintain as list with last element of sorted list
-            nsrdb_fnames = nsrdb_fnames[-1:]  
+            nsrdb_fnames = nsrdb_fnames[-1:]
 
         weather_ds, meta_df = ini_h5_geospatial(nsrdb_fnames)
-        
+
         weather_ds = weather_ds.assign_attrs({"kestrel_nsrdb_fnames": nsrdb_fnames})
 
         # select desired weather attributes

--- a/pvdeg/weather.py
+++ b/pvdeg/weather.py
@@ -609,7 +609,7 @@ def ini_h5_geospatial(fps):
 
 
 def get_NSRDB_fnames(satellite, names, NREL_HPC=False, **_):
-    """Get a list of NSRDB files for a given satellite and year.
+    """Get a sorted list of NSRDB files for a given satellite and year.
 
     Parameters
     ----------
@@ -655,7 +655,7 @@ def get_NSRDB_fnames(satellite, names, NREL_HPC=False, **_):
         nsrdb_fp = os.path.join(
             hpc_fp, sat_map[satellite], "*_{}*.h5".format(names.lower())
         )
-        nsrdb_fnames = glob.glob(nsrdb_fp)
+        nsrdb_fnames = sorted(glob.glob(nsrdb_fp))
 
     if len(nsrdb_fnames) == 0:
         raise FileNotFoundError(
@@ -767,10 +767,14 @@ def get_NSRDB(
         nsrdb_fnames, hsds = get_NSRDB_fnames(satellite, names, NREL_HPC)
 
         if isinstance(names, str) and names.lower() in ["tmy", "tmy3"]:
-            nsrdb_fnames = nsrdb_fnames[-1:]  # maintain as list with last element
+            # maintain as list with last element of sorted list
+            nsrdb_fnames = nsrdb_fnames[-1:]  
 
         weather_ds, meta_df = ini_h5_geospatial(nsrdb_fnames)
+        
+        weather_ds = weather_ds.assign_attrs({"kestrel_nsrdb_fnames": nsrdb_fnames})
 
+        # select desired weather attributes
         if attributes is not None:
             weather_ds = weather_ds[attributes]
 


### PR DESCRIPTION
## Describe your changes

- Sort returned NSRDB TMY fnames and choose the newest year. 
- Add attribute `kestrel_nsrdb_fnames` to weather_ds returned by `pvdeg.weather.get(..., geospatial=True) which contains the list of files used for traceability.

## Issue ticket number and link
Fixes #259 

Example TMY weather dataset loaded with new `kestrel_nsrdb_fnames` attribute
```
<xarray.Dataset> Size: 1TB
Dimensions:            (time: 8760, gid: 2018267)
Coordinates:
  * gid                (gid) int64 16MB 0 1 2 3 ... 2018264 2018265 2018266
  * time               (time) datetime64[ns] 70kB 2024-01-01T00:30:00 ... 202...
Data variables:
    temp_air           (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
    wind_speed         (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
    wind_direction     (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
    dhi                (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
    ghi                (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
    dni                (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
    relative_humidity  (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
    albedo             (time, gid) float64 141GB dask.array<chunksize=(8760, 500), meta=np.ndarray>
Attributes:
    package:               nsrdb
    version:               4.1.2.dev4+g3b38bc8.d20250228
    version_record:        {"nsrdb": "4.1.2.dev4+g3b38bc8.d20250228", "farms"...
    kestrel_nsrdb_fnames:  ['/datasets/NSRDB/current/nsrdb_tmy-2024.h5']
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code changes are covered by tests.
- [x] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [x] What's new changelog has been updated in the docs