### PR TITLE
Simplify dependencies for installation

### DIFF
--- a/docs/source/whatsnew/releases/v0.7.2.rst
+++ b/docs/source/whatsnew/releases/v0.7.2.rst
@@ -20,7 +20,8 @@ Bug Fixes
 Dependencies
 ------------
 - Move ``pre-commit`` from core install requirements to the optional development
-  extras (``dev = ["pre-commit"]``), reducing runtime dependency footprint.
+  extras (``dev = ["pre-commit"]``), and move geospatial analysis dependencies
+  into a new optional ``geo`` extra, reducing the base installation footprint.
   (:issue:`341`, :pull:`347`)
 - Bump aiohttp from 3.13.3 to 3.14.1. (:pull:`344`)
 

--- a/docs/source/whatsnew/releases/v0.7.2.rst
+++ b/docs/source/whatsnew/releases/v0.7.2.rst
@@ -22,6 +22,7 @@ Dependencies
 - Move ``pre-commit`` from core install requirements to the optional development
   extras (``dev = ["pre-commit"]``), reducing runtime dependency footprint.
   (:issue:`341`, :pull:`347`)
+- Bump aiohttp from 3.13.3 to 3.14.0. (:pull:`344`)
 
 
 

--- a/docs/source/whatsnew/releases/v0.7.2.rst
+++ b/docs/source/whatsnew/releases/v0.7.2.rst
@@ -20,8 +20,7 @@ Bug Fixes
 Dependencies
 ------------
 - Move ``pre-commit`` from core install requirements to the optional development
-  extras (``dev = ["pre-commit"]``), and move geospatial analysis dependencies
-  into a new optional ``geo`` extra, reducing the base installation footprint.
+  extras (``dev = ["pre-commit"]``), reducing runtime dependency footprint.
   (:issue:`341`, :pull:`347`)
 - Bump aiohttp from 3.13.3 to 3.14.1. (:pull:`344`)
 

--- a/docs/source/whatsnew/releases/v0.7.2.rst
+++ b/docs/source/whatsnew/releases/v0.7.2.rst
@@ -19,7 +19,10 @@ Bug Fixes
 
 Dependencies
 ------------
-- Bump aiohttp from 3.13.13 to 3.13.4 (:pull:`324`)
+- Move ``pre-commit`` from core install requirements to the optional development
+  extras (``dev = ["pre-commit"]``), reducing runtime dependency footprint.
+  (:issue:`341`, :pull:`347`)
+
 
 
 Contributors

--- a/docs/source/whatsnew/releases/v0.7.2.rst
+++ b/docs/source/whatsnew/releases/v0.7.2.rst
@@ -22,7 +22,7 @@ Dependencies
 - Move ``pre-commit`` from core install requirements to the optional development
   extras (``dev = ["pre-commit"]``), reducing runtime dependency footprint.
   (:issue:`341`, :pull:`347`)
-- Bump aiohttp from 3.13.3 to 3.14.0. (:pull:`344`)
+- Bump aiohttp from 3.13.3 to 3.14.1. (:pull:`344`)
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,17 @@ dependencies = [
     "numpy>=1.19.3",
     "pvlib>=0.12.0",
     "scipy>1.6.0",
+    "NREL-rex",
+    "cartopy",
+    "dask[dataframe]",
+    "dask-jobqueue",
     "bokeh",
+    "geopy",
+    "h5netcdf",
+    "h5py<=3.14.0",
     "jupyterlab",
     "matplotlib",
+    "netCDF4",
     "notebook",
     "numba",
     "openpyxl",
@@ -45,7 +53,9 @@ dependencies = [
     "seaborn",
     "tables",
     "tqdm",
+    "xarray",
     "sympy",
+    "zarr",
     "jupytext",
 ]
 dynamic = ["version"]
@@ -74,23 +84,11 @@ books = [
 sam = [
     "NREL-PySAM",
 ]
-geo = [
-    "NREL-rex",
-    "cartopy",
-    "dask[dataframe]",
-    "dask-jobqueue",
-    "geopy",
-    "h5netcdf",
-    "h5py<=3.14.0",
-    "netCDF4",
-    "xarray",
-    "zarr",
-]
 dev= [
     "pre-commit",
 ]
 all = [
-    "pvdeg[docs,test,books,sam,geo]",
+    "pvdeg[docs,test,books,sam]",
 ]
 
 [project.entry-points.pvdeg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
     "tables",
     "tqdm",
     "xarray",
-    "pre-commit",
     "sympy",
     "zarr",
     "jupytext",
@@ -84,6 +83,9 @@ books = [
 ]
 sam = [
     "NREL-PySAM",
+]
+dev= [
+    "pre-commit",
 ]
 all = [
     "pvdeg[docs,test,books,sam]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,17 +32,9 @@ dependencies = [
     "numpy>=1.19.3",
     "pvlib>=0.12.0",
     "scipy>1.6.0",
-    "NREL-rex",
-    "cartopy",
-    "dask[dataframe]",
-    "dask-jobqueue",
     "bokeh",
-    "geopy",
-    "h5netcdf",
-    "h5py<=3.14.0",
     "jupyterlab",
     "matplotlib",
-    "netCDF4",
     "notebook",
     "numba",
     "openpyxl",
@@ -53,9 +45,7 @@ dependencies = [
     "seaborn",
     "tables",
     "tqdm",
-    "xarray",
     "sympy",
-    "zarr",
     "jupytext",
 ]
 dynamic = ["version"]
@@ -84,11 +74,23 @@ books = [
 sam = [
     "NREL-PySAM",
 ]
+geo = [
+    "NREL-rex",
+    "cartopy",
+    "dask[dataframe]",
+    "dask-jobqueue",
+    "geopy",
+    "h5netcdf",
+    "h5py<=3.14.0",
+    "netCDF4",
+    "xarray",
+    "zarr",
+]
 dev= [
     "pre-commit",
 ]
 all = [
-    "pvdeg[docs,test,books,sam]",
+    "pvdeg[docs,test,books,sam,geo]",
 ]
 
 [project.entry-points.pvdeg]


### PR DESCRIPTION
## Describe your changes

Move pre-commit to dev build option
~Moved several other packages to a geospatial build option~
Attempted to create a geo extra, but most of those packages are imported at the module level, so the pytests can't run because pvdeg itself fails to import on a default install. It's only possible to move dask-jobqueue into geo because it’s imported inside a function in geospatial.py, so it isn’t triggered just by import pvdeg. That alone is not worth it and a major refactor to move all other imports to the function level is beyond the scope of this PR. This might be worth considering in future.

## Issue ticket number and link

Fixes #341 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code changes are covered by tests.
- [ ] Code changes have been evaluated for compatibility/integration with Scenario analysis (for future PRs)
- [ ] Code changes have been evaluated for compatibility/integration with geospatial autotemplating (for future PRs)
- [ ] New functions added to __init__.py
- [ ] API.rst is up to date, along with other sphinx docs pages
- [ ] Example notebooks are rerun and differences in results scrutinized
- [ ] What's new changelog has been updated in the docs
